### PR TITLE
Declare @umask in MemFS::File

### DIFF
--- a/lib/memfs/file.rb
+++ b/lib/memfs/file.rb
@@ -19,6 +19,8 @@ module MemFs
     }
 
     SUCCESS = 0
+    
+    @umask = nil
 
     def_delegators :original_file_class,
                    :basename,


### PR DESCRIPTION
To prevent undefined instance variable warnings when running ruby in warning mode.
