### PR TITLE
Update known issues of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,9 @@ end
 
 ## Known issues
 
-* MemFs doesn't implement IO so FileUtils.copy_stream is still the original one
-* Pipes and Sockets are not handled for now
+* MemFs doesn't implement IO so methods like `FileUtils.copy_stream` and `IO.write` are still the originals.
+* Similarly, MemFs doesn't implement Kernel, so don't use a naked `open()` call. This uses the `Kernel` class via `method_missing`, which MemFs will not intercept.
+* Pipes and Sockets are not handled for now.
 
 ## TODO
 


### PR DESCRIPTION
I spent a couple hours scratching my head why this wasn't working. Unfortunately for me, I came across [an article that led me astray](http://alvinalexander.com/blog/post/ruby/how-write-text-to-file-ruby-example), and I trusted it because it was well written and recent. It said to use `open()`, instead of `File.open`. This is not your fault at all, but thought it might help another poor lost soul out there to mention it.

This is my attempt to help out, based on what I think I know, rather than to just ask you to do it. But by all means, if you're able to take the time to update the README's "TODO" section (at least mentioning what's not implemented), that'd be great.