### PR TITLE
Support 'mode' parameter for Dir.mkdir

### DIFF
--- a/lib/memfs/dir.rb
+++ b/lib/memfs/dir.rb
@@ -64,8 +64,8 @@ module MemFs
       original_dir_class.home(*args)
     end
 
-    def self.mkdir(path)
-      fs.mkdir path
+    def self.mkdir(path, mode = 0777)
+      fs.mkdir path, mode
     end
 
     def self.open(dirname)

--- a/lib/memfs/file_system.rb
+++ b/lib/memfs/file_system.rb
@@ -96,9 +96,11 @@ module MemFs
       find_parent!(new_name).add_entry link
     end
 
-    def mkdir(path)
+    def mkdir(path, mode = 0777)
       fail Errno::EEXIST, path if find(path)
-      find_parent!(path).add_entry Fake::Directory.new(path)
+      directory = Fake::Directory.new(path)
+      directory.mode = mode
+      find_parent!(path).add_entry directory
     end
 
     def paths

--- a/spec/fileutils_spec.rb
+++ b/spec/fileutils_spec.rb
@@ -649,6 +649,26 @@ describe FileUtils do
         expect(File.directory?('/test-dir2')).to be true
       end
     end
+
+    context 'when passing options' do
+      context 'when passing mode parameter' do
+        it 'creates directory with specified permissions' do
+          described_class.mkdir('/test-dir', :mode => 0654)
+          expect(File.exist?('/test-dir')).to be true
+          expect(File.stat('/test-dir').mode).to eq(0100654)
+        end
+      end
+
+      context 'when passing noop parameter' do
+        it 'does not create any directories' do
+          described_class.mkdir(['/test-dir', '/another-dir'], :noop => true)
+          expect(File.directory?('/test-dir')).to be false
+          expect(File.directory?('/another-dir')).to be false
+        end
+      end
+    end
+
+
   end
 
   describe '.mkdir_p' do
@@ -671,6 +691,24 @@ describe FileUtils do
       it "creates each directory's parents" do
         described_class.mkdir_p(['/test-dir', '/path/to/some/test-dir'])
         expect(File.directory?('/path/to/some')).to be true
+      end
+    end
+
+    context 'when passing options' do
+      context 'when passing mode parameter' do
+        it 'creates directory with specified permissions' do
+          described_class.mkdir_p('/test-dir', :mode => 0654)
+          expect(File.exist?('/test-dir')).to be true
+          expect(File.stat('/test-dir').mode).to eq(0100654)
+        end
+      end
+
+      context 'when passing noop parameter' do
+        it 'does not create any directories' do
+          described_class.mkdir_p(['/test-dir', '/another-dir'], :noop => true)
+          expect(File.directory?('/test-dir')).to be false
+          expect(File.directory?('/another-dir')).to be false
+        end
       end
     end
   end

--- a/spec/memfs/dir_spec.rb
+++ b/spec/memfs/dir_spec.rb
@@ -264,6 +264,18 @@ module MemFs
         expect(File.directory?('/new-folder')).to be true
       end
 
+      it 'sets directory permissions to default 0777' do
+        described_class.mkdir '/new-folder'
+        expect(File.stat('/new-folder').mode).to eq(0100777)
+      end
+
+      context 'when permissions are specified' do
+        it 'sets directory permissions to specified value' do
+          described_class.mkdir '/new-folder', 0644
+          expect(File.stat('/new-folder').mode).to eq(0100644)
+        end
+      end
+
       context 'when the directory already exist' do
         it 'raises an exception' do
           expect { described_class.mkdir('/') }.to raise_error(Errno::EEXIST)

--- a/spec/memfs/file_system_spec.rb
+++ b/spec/memfs/file_system_spec.rb
@@ -289,6 +289,18 @@ module MemFs
         expect(subject.find!('/new-dir')).to be_a(Fake::Directory)
       end
 
+      it 'sets directory permissions to default 0777' do
+        subject.mkdir '/new-dir'
+        expect(subject.find!('/new-dir').mode).to eq(0100777)
+      end
+
+      context 'when permissions are specified' do
+        it 'sets directory permission to specified value' do
+          subject.mkdir '/new-dir', 0644
+          expect(subject.find!('/new-dir').mode).to eq(0100644)
+        end
+      end
+
       context 'when a relative path is given' do
         it 'creates a directory in current directory' do
           subject.chdir '/test-dir'


### PR DESCRIPTION
Also such parameter is supported now through options[:mode] by FileUtils.mkdir and FileUtils.mkdir_p