### PR TITLE
NoMethodError: undefined method `write' for MemFs::File:Class

### DIFF
--- a/lib/memfs/io.rb
+++ b/lib/memfs/io.rb
@@ -22,12 +22,19 @@ module MemFs
       def write(path, string, offset = 0, open_args = nil)
         open_args ||= [File::WRONLY, encoding: nil]
 
+        offset = 0 if offset.nil?
+        if offset.respond_to?(:to_int)
+          offset = offset.to_int
+        else
+          raise TypeError, "no implicit conversion from #{offset.class}"
+        end
+
         if offset > 0
           fail NotImplementedError, "MemFs::IO.write with offset not yet supported."
         end
 
         file = open(path, *open_args)
-        file.seek(offset || 0)
+        file.seek(offset)
         file.write(string)
       ensure
         file.close if file

--- a/lib/memfs/io.rb
+++ b/lib/memfs/io.rb
@@ -18,6 +18,20 @@ module MemFs
       ensure
         file.close if file
       end
+
+      def write(path, string, offset = 0, open_args = nil)
+        open_args ||= [File::WRONLY, encoding: nil]
+
+        if offset > 0
+          fail NotImplementedError, "MemFs::IO.write with offset not yet supported."
+        end
+
+        file = open(path, *open_args)
+        file.seek(offset || 0)
+        file.write(string)
+      ensure
+        file.close if file
+      end
     end
 
     module InstanceMethods

--- a/spec/memfs/file_spec.rb
+++ b/spec/memfs/file_spec.rb
@@ -1803,6 +1803,30 @@ module MemFs
       end
     end
 
+    describe '.write' do
+      it 'writes the string to the given file' do
+        described_class.write('/test-file', "test")
+        read_content = described_class.read('/test-file')
+        expect(read_content).to eq "test"
+      end
+
+      context 'when +offset+ is provided' do
+        it 'starts writing from the offset' do
+          pending("Offsets not yet implemented, because Content#write always appends.")
+          described_class.write('/test-file', "test")
+          described_class.write('/test-file', "test", 2)
+          read_content = described_class.read('/test-file')
+          expect(read_content).to eq 'tetest'
+        end
+
+        it 'raises an error if offset is negative' do
+          expect {
+            described_class.write '/test-file', "foo", -1
+          }.to raise_error Errno::EINVAL
+        end
+      end
+    end
+
     describe '.zero?' do
       context 'when the named file exists' do
         context 'and has a zero size' do

--- a/spec/memfs/file_spec.rb
+++ b/spec/memfs/file_spec.rb
@@ -1811,6 +1811,18 @@ module MemFs
       end
 
       context 'when +offset+ is provided' do
+        it 'writes the string to the given file when offset is 0' do
+          described_class.write('/test-file', "test", 0)
+          read_content = described_class.read('/test-file')
+          expect(read_content).to eq "test"
+        end
+
+        it 'writes the string to the given file when offset is nil' do
+          described_class.write('/test-file', "test", nil)
+          read_content = described_class.read('/test-file')
+          expect(read_content).to eq "test"
+        end
+
         it 'starts writing from the offset' do
           pending("Offsets not yet implemented, because Content#write always appends.")
           described_class.write('/test-file', "test")
@@ -1823,6 +1835,18 @@ module MemFs
           expect {
             described_class.write '/test-file', "foo", -1
           }.to raise_error Errno::EINVAL
+        end
+
+        it 'raises an error if offset is a boolean' do
+          expect {
+            described_class.write '/test-file', "foo", false
+          }.to raise_error TypeError
+        end
+
+        it 'raises an error if offset is a string' do
+          expect {
+            described_class.write '/test-file', "foo", "offset"
+          }.to raise_error TypeError
         end
       end
     end


### PR DESCRIPTION
I know that the lack of a `IO.write` implementation is a known issue in the README still, but the more basic usage of it, typically written as `File.write(filename, string)`, is something that compliments the typical `File.read(filename)` quite nicely. 

In my test suite, for now, I'm just manually adding a `MemFs::File.write` method to cover the usage I was using in my project.

```ruby
class MemFs::File
  # MemFs doesn't implement IO.write, because the base implementation allows
  # for file offsets and other options, but it's quite convenient to be able
  # to use File.write in its most basic use case, so let's simulate that.
  def self.write(name, string, offset = nil, open_args = {})
    File.open(name, "w") { |f| f.write(string) }
  end
end
```

I just wanted to open up a discussion about potentially implementing this in memfs. I understand that this is not a complete implementation. I also understand the complexities involved with fully implementing `offset` and `open_args` support.

Right now, I'm at a cross-roads, because I ran into some semi-serious troubles with FakeFS and open-uri. I decided to try MemFs. It seems to work great so far, but I ran into this `File.write` hurdle. I'm now considering dropping a fake filesystem from my test suite altogether, but if I decide to keep MemFs around, I'd be willing to look deeper into a full PR here.

If this isn't worth doing, feel free to close this issue, but I wanted document this, open a discussion, and share (in case any one else might benefit from this).