### PR TITLE
Support Dir.glob with Pathname.

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -169,7 +169,15 @@ Style/StringLiteralsInInterpolation:
   SupportedStyles:
   - single_quotes
   - double_quotes
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
+  Description: Checks for trailing comma in parameter lists and literals.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
+  Enabled: false
+  EnforcedStyleForMultiline: no_comma
+  SupportedStyles:
+  - comma
+  - no_comma
+Style/TrailingCommaInArguments:
   Description: Checks for trailing comma in parameter lists and literals.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
   Enabled: false

--- a/lib/memfs/dir.rb
+++ b/lib/memfs/dir.rb
@@ -47,7 +47,7 @@ module MemFs
     class << self; alias_method :pwd, :getwd; end
 
     def self.glob(patterns, flags = 0)
-      patterns = [*patterns]
+      patterns = [*patterns].map(&:to_s)
       list = fs.paths.select do |path|
         patterns.any? do |pattern|
           File.fnmatch?(pattern, path, flags | GLOB_FLAGS)

--- a/lib/memfs/dir.rb
+++ b/lib/memfs/dir.rb
@@ -143,11 +143,11 @@ module MemFs
 
     private
 
-    if defined?(File::FNM_EXTGLOB)
-      GLOB_FLAGS = File::FNM_EXTGLOB | File::FNM_PATHNAME
-    else
-      GLOB_FLAGS = File::FNM_PATHNAME
-    end
+    GLOB_FLAGS = if defined?(File::FNM_EXTGLOB)
+                   File::FNM_EXTGLOB | File::FNM_PATHNAME
+                 else
+                   File::FNM_PATHNAME
+                 end
 
     attr_accessor :entry, :max_seek, :state
 

--- a/lib/memfs/fake/directory.rb
+++ b/lib/memfs/fake/directory.rb
@@ -45,9 +45,9 @@ module MemFs
 
       def paths
         [path] + entries.reject { |p| %w[. ..].include?(p) }
-                        .values
-                        .map(&:paths)
-                        .flatten
+                 .values
+                 .map(&:paths)
+                 .flatten
       end
 
       def remove_entry(entry)

--- a/lib/memfs/fake/file.rb
+++ b/lib/memfs/fake/file.rb
@@ -33,9 +33,8 @@ module MemFs
       end
 
       def type
-        case
-        when block_device     then 'blockSpecial'
-        when character_device then 'characterSpecial'
+        if block_device then 'blockSpecial'
+        elsif character_device then 'characterSpecial'
         else 'file'
         end
       end

--- a/lib/memfs/file.rb
+++ b/lib/memfs/file.rb
@@ -22,9 +22,9 @@ module MemFs
       'w+' => CREAT | TRUNC | RDWR,
       'a'  => CREAT | APPEND | WRONLY,
       'a+' => CREAT | APPEND | RDWR
-    }
+    }.freeze
 
-    SEPARATOR = '/'
+    SEPARATOR = '/'.freeze
     SUCCESS = 0
 
     @umask = nil
@@ -186,7 +186,7 @@ module MemFs
 
     def self.size?(path)
       file = fs.find(path)
-      if file && file.size > 0
+      if file && file.size > 0 # rubocop:disable Style/ZeroLengthPredicate
         file.size
       else
         false
@@ -240,7 +240,7 @@ module MemFs
     def initialize(filename, mode = File::RDONLY, *perm_and_or_opt)
       opt = perm_and_or_opt.last.is_a?(Hash) ? perm_and_or_opt.pop : {}
       perm_and_or_opt.shift
-      if perm_and_or_opt.size > 0
+      unless perm_and_or_opt.empty?
         fail ArgumentError, 'wrong number of arguments (4 for 1..3)'
       end
 
@@ -296,8 +296,6 @@ module MemFs
       File.truncate(path, integer)
     end
 
-    private
-
     def self.dereference_name(path)
       entry = fs.find(path)
       if entry
@@ -330,13 +328,13 @@ module MemFs
 
     def self.stat_query(path, query, force_boolean = true)
       response = fs.find(path) && stat(path).public_send(query)
-      force_boolean ? !!(response) : response
+      force_boolean ? !!response : response
     end
     private_class_method :stat_query
 
     def self.lstat_query(path, query)
       response = fs.find(path) && lstat(path).public_send(query)
-      !!(response)
+      !!response
     end
     private_class_method :lstat_query
   end

--- a/lib/memfs/file/stat.rb
+++ b/lib/memfs/file/stat.rb
@@ -21,7 +21,7 @@ module MemFs
                      :uid
 
       def blockdev?
-        !!(entry.block_device)
+        !!entry.block_device
       end
 
       def chardev?

--- a/lib/memfs/file_system.rb
+++ b/lib/memfs/file_system.rb
@@ -21,7 +21,7 @@ module MemFs
       previous_directory = working_directory
       self.working_directory = destination
 
-      block.call if block
+      yield if block
     ensure
       self.working_directory = previous_directory if block
     end

--- a/lib/memfs/io.rb
+++ b/lib/memfs/io.rb
@@ -109,25 +109,25 @@ module MemFs
         end
       end
 
-      def each(sep = $/, &block)
+      def each(sep = $/)
         return to_enum(__callee__) unless block_given?
         fail IOError, 'not opened for reading' unless readable?
-        content.each_line(sep) { |line| block.call(line) }
+        content.each_line(sep) { |line| yield(line) }
         self
       end
 
-      def each_byte(&block)
+      def each_byte
         return to_enum(__callee__) unless block_given?
         fail IOError, 'not opened for reading' unless readable?
-        content.each_byte { |byte| block.call(byte) }
+        content.each_byte { |byte| yield(byte) }
         self
       end
       alias_method :bytes, :each_byte
 
-      def each_char(&block)
+      def each_char
         return to_enum(__callee__) unless block_given?
         fail IOError, 'not opened for reading' unless readable?
-        content.each_char { |char| block.call(char) }
+        content.each_char { |char| yield(char) }
         self
       end
       alias_method :chars, :each_char

--- a/lib/memfs/version.rb
+++ b/lib/memfs/version.rb
@@ -1,3 +1,3 @@
 module MemFs
-  VERSION = '0.5.0'
+  VERSION = '0.5.0'.freeze
 end

--- a/spec/memfs/dir_spec.rb
+++ b/spec/memfs/dir_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'pathname'
 
 module MemFs
   describe Dir do
@@ -216,6 +217,9 @@ module MemFs
       it_behaves_like 'returning matching filenames', '/test?', %w[/test0 /test1 /test2]
       it_behaves_like 'returning matching filenames', '/test[01]', %w[/test0 /test1]
       it_behaves_like 'returning matching filenames', '/test[^2]', %w[/test0 /test1]
+      it_behaves_like 'returning matching filenames', Pathname.new('/'), %w[/]
+      it_behaves_like 'returning matching filenames', Pathname.new('/*'),
+        %w[/tmp /test0 /test1 /test2]
 
       if defined?(File::FNM_EXTGLOB)
         it_behaves_like 'returning matching filenames', '/test{1,2}', %w[/test1 /test2]

--- a/spec/memfs/dir_spec.rb
+++ b/spec/memfs/dir_spec.rb
@@ -219,7 +219,7 @@ module MemFs
       it_behaves_like 'returning matching filenames', '/test[^2]', %w[/test0 /test1]
       it_behaves_like 'returning matching filenames', Pathname.new('/'), %w[/]
       it_behaves_like 'returning matching filenames', Pathname.new('/*'),
-        %w[/tmp /test0 /test1 /test2]
+                      %w[/tmp /test0 /test1 /test2]
 
       if defined?(File::FNM_EXTGLOB)
         it_behaves_like 'returning matching filenames', '/test{1,2}', %w[/test1 /test2]

--- a/spec/memfs/file_spec.rb
+++ b/spec/memfs/file_spec.rb
@@ -2250,7 +2250,7 @@ module MemFs
       context 'when the file is not open for reading' do
         it 'raises an exception' do
           expect {
-            write_subject.each_byte { |b| }
+            write_subject.each_byte { |_b| }
           }.to raise_error IOError
         end
 
@@ -2287,7 +2287,7 @@ module MemFs
       context 'when the file is not open for reading' do
         it 'raises an exception' do
           expect {
-            write_subject.each_char { |b| }
+            write_subject.each_char { |_b| }
           }.to raise_error IOError
         end
 


### PR DESCRIPTION
This works with stdlib:

    require 'pathname'
    p = Pathname.new('/')
    Dir[p]
    # => ["/"]

But before this change failed under MemFs:

    TypeError:
      no implicit conversion of Pathname into String

This is more likely to be encountered in a Rails project where
`Rails.root` is a `Pathname`, but it's very possible to encounter this
in an Ruby project.