### PR TITLE
Switch between fake & real fs.

### DIFF
--- a/lib/memfs.rb
+++ b/lib/memfs.rb
@@ -70,7 +70,7 @@ module MemFs
   #
   # @see #deactivate!
   # @return nothing.
-  def activate!
+  def activate!(clear: true)
     Object.class_eval do
       remove_const :Dir
       remove_const :File
@@ -79,7 +79,7 @@ module MemFs
       const_set :File, MemFs::File
     end
 
-    MemFs::FileSystem.instance.clear!
+    MemFs::FileSystem.instance.clear! if clear
   end
   module_function :activate!
 
@@ -112,18 +112,11 @@ module MemFs
   #   end
   # @return nothing
   def halt
-    # Keep fake fs state
-    fs    = MemFs::FileSystem.instance
-    state = Hash[fs.instance_variables.map { |key| [key, fs.instance_variable_get(key)] } ]
-
     deactivate!
     
     yield if block_given?
   ensure
-    activate!
-
-    # Recover fake fs state
-    state.each { |key, value| fs.instance_variable_set(key, value) }
+    activate!(clear: false) 
   end
   module_function :halt
 

--- a/spec/memfs_spec.rb
+++ b/spec/memfs_spec.rb
@@ -50,6 +50,36 @@ describe MemFs do
     end
   end
 
+  describe '.halt' do
+    before :each do
+      described_class.activate!
+      described_class.deactivate!
+    end
+
+    it 'switches back to the original Ruby Dir & File classes' do
+      described_class.halt do
+        expect(::Dir).to be(described_class::OriginalDir)
+        expect(::File).to be(described_class::OriginalFile)
+      end
+    end
+
+    it 'switches back to the faked Dir & File classes' do
+      described_class.halt
+      expect(::Dir).to be(described_class::Dir)
+      expect(::File).to be(described_class::File)
+    end
+
+    it 'maintains the state of the faked fs' do
+      _fs.touch('file.rb')
+
+      described_class.halt do
+        expect(File.exist?('file.rb')).to be false
+      end
+          
+      expect(File.exist?('file.rb')).to be true
+    end
+  end
+
   describe '.touch' do
     around(:each) { |example| described_class.activate { example.run } }
 

--- a/spec/memfs_spec.rb
+++ b/spec/memfs_spec.rb
@@ -51,10 +51,8 @@ describe MemFs do
   end
 
   describe '.halt' do
-    before :each do
-      described_class.activate!
-      described_class.deactivate!
-    end
+    before(:each) { described_class.activate! }
+    after(:each)  { described_class.deactivate! }
 
     it 'switches back to the original Ruby Dir & File classes' do
       described_class.halt do
@@ -67,6 +65,15 @@ describe MemFs do
       described_class.halt
       expect(::Dir).to be(described_class::Dir)
       expect(::File).to be(described_class::File)
+    end
+
+    it 'switches back to the faked Dir & File classes no matter what' do
+      begin
+        described_class.halt { raise StandardError.new }
+      rescue
+        expect(::Dir).to be(described_class::Dir)
+        expect(::File).to be(described_class::File)
+      end
     end
 
     it 'maintains the state of the faked fs' do


### PR DESCRIPTION
Somewhat related to  #23 & #7 - I needed to read from the original file system, and this is what I came up with to switch between both file systems.

Background story: I'm testing a command line app lazy-loading subcommands via some loader class that `require`s the appropriate files. With the switch implemented, mocking the loader was easy as saying:

```Ruby
class Loader
    
  alias_method :_load, :load

  def load(file)
    MemFs.halt { _load(file) }
  end

end
```      

So this is might be a valid use case, or it might be not, or it might be a stupid implementation, but I thought to give it a try.
