### PR TITLE
Add basic File::Stat#nlink method

### DIFF
--- a/lib/memfs/file/stat.rb
+++ b/lib/memfs/file/stat.rb
@@ -60,6 +60,10 @@ module MemFs
         @entry = dereference ? entry.dereferenced : entry
       end
 
+      def nlink
+        directory? ? 2 : 1
+      end
+
       def owned?
         uid == Process.euid
       end

--- a/spec/memfs/file/stat_spec.rb
+++ b/spec/memfs/file/stat_spec.rb
@@ -373,6 +373,18 @@ module MemFs
       end
     end
 
+    describe '#nlink' do
+      context 'when the entry is a regular file' do
+        it "returns expected nlinks for a file" do
+          expect(file_stat.nlink).to eq(1)
+        end
+
+        it "returns expected nlinks for a directory" do
+          expect(dir_stat.nlink).to eq(2)
+        end
+      end
+    end
+
     describe '#ftype' do
       context 'when the entry is a regular file' do
         it "returns 'file'" do


### PR DESCRIPTION
This adds a basic nlink method that's hard coded to 1 for files and 2 for directories, i.e. the defaults for simple cases.

Original issue at https://github.com/simonc/memfs/issues/35

I was going to try to do something more realistic, but wasn't satisified with my ultimately incomplete solution. There's probably a good way to accomplish it using internal methods, but it escaped me.