### PR TITLE
Fix kwargs handling compatibility with rspec-mocks 3.12+

### DIFF
--- a/spec/memfs/file_spec.rb
+++ b/spec/memfs/file_spec.rb
@@ -1073,7 +1073,7 @@ module MemFs
         it 'passes the contained options to +open+' do
           expect(described_class).to \
             receive(:open)
-            .with('/test-file', File::RDONLY, encoding: 'UTF-8')
+            .with('/test-file', File::RDONLY, { encoding: 'UTF-8' })
             .and_return(subject)
 
           described_class.read '/test-file', encoding: 'UTF-8'


### PR DESCRIPTION
MemFs test suite fails with rspec-mocks 3.12+:

~~~
  1) MemFs::File.read when the last argument is a hash passes the contained options to +open+
     Failure/Error: file = open(path, *open_args)
       #<MemFs::File (class)> received :open with unexpected arguments
         expected: ("/test-file", 0, {:encoding=>"UTF-8"}) (keyword arguments)
              got: ("/test-file", 0, {:encoding=>"UTF-8"}) (options hash)
     # ./lib/memfs/io.rb:29:in `read'
     # ./spec/memfs/file_spec.rb:1038:in `block (4 levels) in <module:MemFs>'
~~~

And this is speculative fix. I have not tested it in any way. I was hoping that CI here will help me validate, but I am not sure that CI runs anymore ....