### PR TITLE
Correct the read and execute bitmasks

### DIFF
--- a/lib/memfs/fake/entry.rb
+++ b/lib/memfs/fake/entry.rb
@@ -3,15 +3,15 @@
 module MemFs
   module Fake
     class Entry
-      UREAD  = 0o0100
+      UREAD  = 0o0400
       UWRITE = 0o0200
-      UEXEC  = 0o0400
-      GREAD  = 0o0010
+      UEXEC  = 0o0100
+      GREAD  = 0o0040
       GWRITE = 0o0020
-      GEXEC  = 0o0040
-      OREAD  = 0o0001
+      GEXEC  = 0o0010
+      OREAD  = 0o0004
       OWRITE = 0o0002
-      OEXEC  = 0o0004
+      OEXEC  = 0o0001
       RSTICK = 0o1000
       USTICK = 0o5000
       SETUID = 0o4000


### PR DESCRIPTION
Hello!

While debugging a test I was writing with MemFS, I realized that `File.readable?` was returning `true` when only the execute bits were set on the file (e.g. `chmod 111`) and not when the read bits were set (e.g. `chmod 444`). That led me here where I discovered the bit masks for read versus execute are swapped in MemFS.

Please let me know if there are any additional updates I should make.

Thank you!