### PR TITLE
Updates for Windows paths, groups and owners

### DIFF
--- a/lib/memfs/file.rb
+++ b/lib/memfs/file.rb
@@ -125,7 +125,7 @@ module MemFs
       # in-memory filesystem: convert backslashes to forward slashes and
       # strip an optional drive letter (e.g. C:)
       path = path.tr('\\', '/')
-      path.sub(%r{\A[A-Za-z]:}, '')
+      path.sub(/\A[A-Za-z]:/, '')
     end
 
     def self.ftype(path)

--- a/lib/memfs/file.rb
+++ b/lib/memfs/file.rb
@@ -81,7 +81,7 @@ module MemFs
     end
 
     def self.absolute_path(path, dir_string = fs.pwd)
-      original_file_class.absolute_path(path, dir_string)
+      normalize_path(original_file_class.absolute_path(path, dir_string))
     end
 
     def self.atime(path)
@@ -115,7 +115,17 @@ module MemFs
     class << self; alias exist? exists?; end
 
     def self.expand_path(file_name, dir_string = fs.pwd)
-      original_file_class.expand_path(file_name, dir_string)
+      normalize_path(original_file_class.expand_path(file_name, dir_string))
+    end
+
+    private_class_method def self.normalize_path(path)
+      return path unless MemFs.windows?
+
+      # Normalize Windows-style paths to a posix-like path used by the
+      # in-memory filesystem: convert backslashes to forward slashes and
+      # strip an optional drive letter (e.g. C:)
+      path = path.tr('\\', '/')
+      path.sub(%r{\A[A-Za-z]:}, '')
     end
 
     def self.ftype(path)

--- a/spec/memfs/file/stat_spec.rb
+++ b/spec/memfs/file/stat_spec.rb
@@ -453,7 +453,8 @@ module MemFs
 
       context 'when the effective user group does not own of the file' do
         it 'returns false' do
-          _fs.chown(0, 0, '/test-file')
+          other_gid = Process.egid == 0 ? 1 : 0
+          _fs.chown(0, other_gid, '/test-file')
           expect(file_stat.grpowned?).to be false
         end
       end
@@ -482,7 +483,8 @@ module MemFs
 
       context 'when the effective user does not own of the file' do
         it 'returns false' do
-          _fs.chown(0, 0, '/test-file')
+          other_uid = Process.euid == 0 ? 1 : 0
+          _fs.chown(other_uid, 0, '/test-file')
           expect(file_stat.owned?).to be false
         end
       end

--- a/spec/memfs/file_spec.rb
+++ b/spec/memfs/file_spec.rb
@@ -662,8 +662,8 @@ module MemFs
 
         context 'and the effective user group does not own of the file' do
           it 'returns false' do
-            described_class.chown 0, 0, '/test-file'
-
+            other_gid = Process.egid == 0 ? 1 : 0
+            described_class.chown 0, other_gid, '/test-file'
             grpowned = File.grpowned?('/test-file')
             expect(grpowned).to be false
           end
@@ -1013,8 +1013,8 @@ module MemFs
 
         context 'and the effective user does not own of the file' do
           it 'returns false' do
-            described_class.chown 0, 0, '/test-file'
-
+            other_uid = Process.euid == 0 ? 1 : 0
+            described_class.chown other_uid, 0, '/test-file'
             owned = File.owned?('/test-file')
             expect(owned).to be false
           end


### PR DESCRIPTION
Normalized Windows drive-letter paths and made tests resilient to systems where Process.euid/egid are 0.

Courtesy of Raptor mini.